### PR TITLE
(CWC-440) Feat/add codebuild job

### DIFF
--- a/bzero-agent-release.yml
+++ b/bzero-agent-release.yml
@@ -1,0 +1,40 @@
+# spec:
+# https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html
+version: 0.2
+env:
+  variables:
+    TZ: "America/New_York date"
+    ReleaseDir: bzero-release
+  git-credential-helper: yes
+phases:
+  install:
+    runtime-versions:
+      golang: 1.14
+  pre_build:
+    commands:
+      - echo Pre-Build started...
+      - git fetch --tags
+      - LatestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
+      - grep -q 'bzero-' <<< $LatestTag && echo "Tag is valid" || (echo "Tag $LatestTag is invalid" && exit 1)
+      - git checkout $LatestTag
+      - LatestVersion=$(echo $LatestTag | sed 's/bzero-//g' )
+      - echo $LatestVersion > VERSION
+  build:
+    commands:
+      - echo Build started...
+      - make bzero-release
+  post_build:
+    commands:
+      - echo Post build started...
+      - echo Copying all files to $LatestVersion folder...
+      - mkdir -p $ReleaseDir/$LatestVersion
+      - cp -a bin/VERSION $ReleaseDir/$LatestVersion
+      - cp -a bin/linux_amd64/bzero-ssm-agent.rpm $ReleaseDir/$LatestVersion
+      - cp -a bin/debian_amd64/bzero-ssm-agent.deb $ReleaseDir/$LatestVersion
+      - echo Copying all files to latest folder...
+      - cp -a $ReleaseDir/$LatestVersion $ReleaseDir/latest
+artifacts:
+  files:
+    - "**/*"
+  base-directory: $ReleaseDir
+  name: release


### PR DESCRIPTION
Relates to JIRA: CWC-440

This PR adds the code build job that will be used by aws CodeBuild. 
We will assume there to be a tag in the form `bzero-123` where `123` is the version we want to build. 

This codebuild job will then grab the latest tag, and attempt to build the latest version of `bzero-ssm-agent`
