### PR TITLE
(CWC-454) Add -keygen command to build and store keys

### DIFF
--- a/core/agent.go
+++ b/core/agent.go
@@ -39,7 +39,7 @@ const (
 	versionFlag             = "version"
 	fingerprintFlag         = "fingerprint"
 	similarityThresholdFlag = "similarityThreshold"
-	getPubKeyFlag           = "getPubKey"
+	bzeroInfoFlag           = "bzeroInfo"
 )
 
 const (
@@ -47,10 +47,10 @@ const (
 )
 
 var (
-	activationCode, activationID, region, orgID                  string
-	register, clear, force, fpFlag, agentVersionFlag, pubKeyFlag bool
-	similarityThreshold                                          int
-	registrationFile                                             = filepath.Join(appconfig.DefaultDataStorePath, "registration")
+	activationCode, activationID, region, orgID                 string
+	register, clear, force, fpFlag, agentVersionFlag, bzeroInfo bool
+	similarityThreshold                                         int
+	registrationFile                                            = filepath.Join(appconfig.DefaultDataStorePath, "registration")
 )
 
 func start(log logger.T) (app.CoreAgent, logger.T, error) {

--- a/core/agent_darwin.go
+++ b/core/agent_darwin.go
@@ -31,13 +31,13 @@ func main() {
 	// parse input parameters
 	parseFlags()
 	handleAgentVersionFlag()
+	handleBZeroInfo()
 
 	// initialize logger
 	log := logger.SSMLogger(true)
 	defer log.Close()
 	defer log.Flush()
 
-	handleGetPubKey(log)
 	setProxySettings(log)
 	handleRegistrationAndFingerprintFlags(log)
 

--- a/core/agent_parser.go
+++ b/core/agent_parser.go
@@ -63,38 +63,42 @@ func parseFlags() {
 	// force flag
 	flag.BoolVar(&force, "y", false, "")
 
-	// Show Pub Key flag
-	flag.BoolVar(&pubKeyFlag, getPubKeyFlag, false, "")
+	// Show bzeroInfo flag
+	flag.BoolVar(&bzeroInfo, bzeroInfoFlag, false, "")
 
 	flag.Parse()
 }
 
-func handleGetPubKey(log logger.T) {
-	// BZero helper function to:
-	// * Get and show the public key
-	if flag.NFlag() > 0 {
-		if pubKeyFlag {
-			bzeroConfig := map[string]string{}
-
-			config, err := vault.Retrieve(BZeroConfig)
-			if err != nil {
-				log.Errorf("Error retriving BZero config: %v", err)
-				os.Exit(1)
-			} else if config == nil {
-				log.Error("BZero Config file is empty!")
-				os.Exit(1)
-			}
-
-			// Unmarshal the retrieved data
-			if err := json.Unmarshal([]byte(config), &bzeroConfig); err != nil {
-				log.Errorf("Error retriving BZero config: %v", err)
-				os.Exit(1)
-			}
-
-			fmt.Println(bzeroConfig["PublicKey"])
+func handleBZeroInfo() {
+	if flag.NFlag() == 1 {
+		if bzeroInfo {
+			fmt.Println("BZero Agent Version: " + version.Version)
+			printBZeroPubKey()
 			os.Exit(0)
 		}
 	}
+}
+
+// This function is without logger and will not print extra statements
+func printBZeroPubKey() {
+	bzeroConfig := map[string]string{}
+
+	config, err := vault.Retrieve(BZeroConfig)
+	if err != nil {
+		fmt.Printf("Error retriving BZero config: %v", err)
+		os.Exit(1)
+	} else if config == nil {
+		fmt.Printf("BZero Config file is empty!")
+		os.Exit(1)
+	}
+
+	// Unmarshal the retrieved data
+	if err := json.Unmarshal([]byte(config), &bzeroConfig); err != nil {
+		fmt.Printf("Error retriving BZero config: %v", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(bzeroConfig["PublicKey"])
 }
 
 func bzeroInit(log logger.T) {

--- a/core/agent_unix.go
+++ b/core/agent_unix.go
@@ -11,13 +11,13 @@ func main() {
 	// parse input parameters
 	parseFlags()
 	handleAgentVersionFlag()
+	handleBZeroInfo()
 
 	// initialize logger
 	log := logger.SSMLogger(true)
 	defer log.Close()
 	defer log.Flush()
 
-	handleGetPubKey(log)
 	handleRegistrationAndFingerprintFlags(log)
 
 	// run agent


### PR DESCRIPTION
Relates to JIRA: CWC-454

This PR adds a `-keygen` command to `bzero-ssm-agent`. This command will generate a new private / public keypair and store it in `/var/lib/bzero/ssm/Vault/Store`. Example file seen here: 
```json
{"PrivateKey":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPtCs7dYJQ10E/PDXrkm9cNYZECut\nBBOpIe1g1skm8G1XNpYT+MwUHLF0xtXjunh8jgABS0MjdVeIawLhsbNMRA==\n-----END PUBLIC KEY-----\n","PublicKey":"-----BEGIN PRIVATE KEY-----\nMHcCAQEEIITYMu9impzs38PnBpvZ3Oik+FzRCxLOtvLhBdiTMVTToAoGCCqGSM49\nAwEHoUQDQgAEPtCs7dYJQ10E/PDXrkm9cNYZECutBBOpIe1g1skm8G1XNpYT+MwU\nHLF0xtXjunh8jgABS0MjdVeIawLhsbNMRA==\n-----END PRIVATE KEY-----\n"}
```