### PR TITLE
Add orgProvider flag to registration command

### DIFF
--- a/core/agent.go
+++ b/core/agent.go
@@ -35,6 +35,7 @@ const (
 	activationIDFlag        = "id"
 	regionFlag              = "region"
 	orgIDFlag               = "org"
+	orgProviderFlag         = "orgProvider"
 	registerFlag            = "register"
 	versionFlag             = "version"
 	fingerprintFlag         = "fingerprint"
@@ -47,7 +48,7 @@ const (
 )
 
 var (
-	activationCode, activationID, region, orgID                 string
+	activationCode, activationID, region, orgID, orgProvider    string
 	register, clear, force, fpFlag, agentVersionFlag, bzeroInfo bool
 	similarityThreshold                                         int
 	registrationFile                                            = filepath.Join(appconfig.DefaultDataStorePath, "registration")

--- a/core/agent_parser.go
+++ b/core/agent_parser.go
@@ -52,6 +52,7 @@ func parseFlags() {
 
 	// OrgID flag
 	flag.StringVar(&orgID, orgIDFlag, "", "")
+	flag.StringVar(&orgProvider, orgProviderFlag, "", "")
 
 	// clear registration
 	flag.BoolVar(&clear, "clear", false, "")
@@ -122,9 +123,10 @@ func bzeroInit(log logger.T) {
 	// Marshal our data before storing it
 	privatekeyString, pubkeyString := encode(privatekey, pubkey)
 	keys := map[string]string{
-		"PublicKey":      pubkeyString,
-		"PrivateKey":     privatekeyString,
-		"OrganizationID": orgID,
+		"PublicKey":            pubkeyString,
+		"PrivateKey":           privatekeyString,
+		"OrganizationID":       orgID,
+		"OrganizationProvider": orgProvider,
 	}
 	data, err := json.Marshal(keys)
 	if err != nil {


### PR DESCRIPTION
In addition to organizationId we also allow passing in orgProvider string which should be a string with values either "google" or "microsoft" 