### PR TITLE
(CWC-545) Return ErrorType in Keysplitting Errors

### DIFF
--- a/agent/session/contracts/model.go
+++ b/agent/session/contracts/model.go
@@ -447,25 +447,49 @@ type DataAckPayloadPayload struct {
 	TargetPublicKey string `json:"targetPublicKey"`
 }
 
+type KeySplittingErrorType string
+
+// Error types
+const (
+	// Catch-all unknown error type
+	Unknown KeySplittingErrorType = "Unknown"
+
+	// BZECert Validation Errors
+	BZECertIDTokenValidationError KeySplittingErrorType = "BZECertIDTokenValidationError"
+	BZECertInvalidNonce           KeySplittingErrorType = "BZECertInvalidNonce"
+	BZECertUnverifiedEmail        KeySplittingErrorType = "BZECertUnverifiedEmail"
+	BZECertInvalidHash            KeySplittingErrorType = "BZECertInvalidHash"
+)
+
 // This error is to help return the SYNACK or DATACK in the correct
 // Datachannel object.  One of the payload will always be empty and we'll
 // switch based on the Err.Error() because Go doesn't have generics yet.
-type KeysplittingError struct {
+type WrappedKeysplittingError struct {
 	Err     error
 	Content interface{}
 }
 
-func (r *KeysplittingError) Error() string {
+func (r *WrappedKeysplittingError) Error() string {
 	return r.Err.Error()
 }
 
 type ErrorPayloadPayload struct {
-	Message         string `json:"message"`
-	HPointer        string `json:"hPointer"`
-	TargetPublicKey string `json:"targetPublicKey"`
+	Message         string                `json:"message"`
+	HPointer        string                `json:"hPointer"`
+	TargetPublicKey string                `json:"targetPublicKey"`
+	ErrorType       KeySplittingErrorType `json:"errorType"`
 }
 
 type ErrorPayload struct {
 	Payload   ErrorPayloadPayload `json:"payload"`
 	Signature string              `json:"signature"`
+}
+
+type KeySplittingError struct {
+	ErrorType KeySplittingErrorType
+	Err       error
+}
+
+func (r *KeySplittingError) Error() string {
+	return r.Err.Error()
 }

--- a/agent/session/datachannel/datachannel.go
+++ b/agent/session/datachannel/datachannel.go
@@ -878,17 +878,9 @@ func (dataChannel *DataChannel) processStreamDataMessage(log log.T, streamDataMe
 		}
 
 		if err = dataChannel.inputStreamMessageHandler(log, streamDataMessage); err != nil {
-			if err, ok := err.(*mgsContracts.KeysplittingError); ok { // Check if error is of type KeysplittingError
+			if err, ok := err.(*mgsContracts.WrappedKeysplittingError); ok { // Check if error is of type WrappedKeysplittingError
 				dataChannel.SendKeysplittingMessage(log, err.Content)
-				// switch err.Error() {
-				// case "SYNACK":
-				// 	dataChannel.SendKeysplittingMessage(log, err.Content)
-				// case "DATAACK":
-				// 	dataChannel.SendKeysplittingMessage(log, err.Content)
-				// case "ERROR":
-				// 	dataChannel.SendKeysplittingMessage(log, err.Content)
-				// }
-			} else { // If it's not of type KeysplittingError, then return it because it's just a normal error
+			} else { // If it's not of type WrappedKeysplittingError, then return it because it's just a normal error
 				return err
 			}
 		}


### PR DESCRIPTION
+ New string type `KeySplittingErrorType` to define all specific error types
+ Rename `KeysplittingError` => `WrappedKeySplittingError`: `WrappedKeySplittingError` now includes an `ErrorType` in the payload as a string
+ New struct `KeySplittingErrorType` which implements `Error` interface but also contains a `KeySplittingErrorType` and can be returned by validation helper methods.