### PR TITLE
Set aws creds env var path

### DIFF
--- a/packaging/linux/amazon-ssm-agent.conf
+++ b/packaging/linux/amazon-ssm-agent.conf
@@ -20,5 +20,5 @@ stop on (runlevel [!345] or stopping network)
 
 respawn
 
-env AWS_SHARED_CREDENTIALS_FILE=/root/.bzero/credentials
+env AWS_SHARED_CREDENTIALS_FILE=~/.bzero/credentials
 exec /usr/bin/bzero-ssm-agent

--- a/packaging/linux/amazon-ssm-agent.service
+++ b/packaging/linux/amazon-ssm-agent.service
@@ -7,7 +7,7 @@ Type=simple
 WorkingDirectory=/usr/bin/
 ExecStart=/usr/bin/bzero-ssm-agent
 KillMode=process
-Environment=AWS_SHARED_CREDENTIALS_FILE=/root/.bzero/credentials
+Environment=AWS_SHARED_CREDENTIALS_FILE=~/.bzero/credentials
 
 # Restart the agent regardless of whether it crashes (and returns a non-zero result code) or if
 # is terminated normally (e.g. via 'kill -HUP').  Delay restart so that the agent is less likely

--- a/packaging/ubuntu/amazon-ssm-agent.conf
+++ b/packaging/ubuntu/amazon-ssm-agent.conf
@@ -20,5 +20,5 @@ stop on runlevel [!2345]
 
 respawn 
 
-env AWS_SHARED_CREDENTIALS_FILE=/root/.bzero/credentials
+env AWS_SHARED_CREDENTIALS_FILE=~/.bzero/credentials
 exec /usr/bin/bzero-ssm-agent

--- a/packaging/ubuntu/amazon-ssm-agent.service
+++ b/packaging/ubuntu/amazon-ssm-agent.service
@@ -7,7 +7,7 @@ Type=simple
 WorkingDirectory=/usr/bin/
 ExecStart=/usr/bin/bzero-ssm-agent
 KillMode=process
-Environment=AWS_SHARED_CREDENTIALS_FILE=/root/.bzero/credentials
+Environment=AWS_SHARED_CREDENTIALS_FILE=~/.bzero/credentials
 
 # Restart the agent regardless of whether it crashes (and returns a non-zero result code) or if
 # is terminated normally (e.g. via 'kill -HUP').  Delay restart so that the agent is less likely


### PR DESCRIPTION
Relates to issue where IAM role on the target would get overridden by our Bzero agent. These changes ensure that our credentials get put in a different place (i.e. ~/.bzero/credentials vs ~/.aws/credentials)