### PR TITLE
Change the name of the build artifacts directory used by codepipeline-build.yml

### DIFF
--- a/bzero-release/codebuild/codepipeline-build.yml
+++ b/bzero-release/codebuild/codepipeline-build.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     TZ: "America/New_York date"
-    ReleaseDir: bzero-release
+    ReleaseDir: bzero-release-artifacts
   exported-variables:
     - AgentVersion
 phases:


### PR DESCRIPTION
Change this directory so it doesnt collide with the existing bzero-release directory (part of source code) which contains the
codebuild` spec yaml files used by the codepipeline. Otherwise the final published artifacts will include these yaml files.