### PR TITLE
Fix Hpointers

### DIFF
--- a/agent/keysplitting/util.go
+++ b/agent/keysplitting/util.go
@@ -193,12 +193,12 @@ func (k *KeysplittingHelper) ValidateDataMessage(datapayload kysplContracts.Data
 // If this is the beginning of the hash chain, then we create a nonce with a random value,
 // otherwise we use the hash of the previous value to maintain the hash chain and immutability
 func (k *KeysplittingHelper) GetNonce() string {
-	if k.HPointer == "" {
+	if k.ExpectedHPointer == "" {
 		b := make([]byte, 32) // 32-length byte array, to make it same length as hash pointer
 		rand.Read(b)          // populate with random bytes
 		return base64.StdEncoding.EncodeToString(b)
 	} else {
-		return k.HPointer
+		return k.ExpectedHPointer
 	}
 }
 
@@ -480,7 +480,6 @@ func (k *KeysplittingHelper) BuildSynAck(nonce string, synpayload kysplContracts
 
 	// Update expectedHPointer aka the hpointer in the next received message to be H(SYNACK)
 	k.ExpectedHPointer, _ = k.HashStruct(contentPayload)
-	k.HPointer = k.ExpectedHPointer
 
 	return &kysplContracts.KeysplittingError{
 		Err:     errors.New("SYNACK"),
@@ -510,7 +509,6 @@ func (k *KeysplittingHelper) BuildDataAck(datapayload kysplContracts.DataPayload
 
 	// Update expectedHPointer aka the hpointer in the next received message to be H(DATAACK)
 	k.ExpectedHPointer, _ = k.HashStruct(contentPayload)
-	k.HPointer = k.ExpectedHPointer
 
 	return &kysplContracts.KeysplittingError{
 		Err:     errors.New("DATAACK"),


### PR DESCRIPTION
## Description of the change

Previously, the HPointer was only updated on an incoming message.  That means that during shell attachment, the incoming message would be used to continue the hash chain as opposed to the ACK of that message.  Now, we execute the following when we send `SYN/ACK`, `DATA/ACK`, and `ERROR` Messages:
      
>     ExpectedHPointer, _ = Hash(previous message)
>     HPointer = ExpectedHPointer

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-839

## Relevant release note information

Release Notes:  
- Fix bug in how we update hash pointers

## Potential Security Impacts

Does this PR have any security impact? Yes
Does it fix a security issue? Yes
Does it add attack surface? No
Why do we think this change is safe? Minor change so that we follow spec

## Checklists

### Development

- [x] Does the code changed/added as part of this pull request have test coverage?
- [x] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [x] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
