### PR TITLE
fix error checking logic on http response

### DIFF
--- a/agent/bzero/registration/registration.go
+++ b/agent/bzero/registration/registration.go
@@ -190,11 +190,11 @@ func sendRequestWithRetry(log logger.T, req *http.Request) (*http.Response, erro
 
 			ticker.Stop()
 			return nil, fmt.Errorf("received response code: %d, not retrying", response.StatusCode)
-		} else if response.StatusCode != http.StatusOK {
-			continue
-		} else {
+		} else if response.StatusCode >= 200 && response.StatusCode < 300 {
 			ticker.Stop()
 			return response, nil
+		} else {
+			continue
 		}
 	}
 


### PR DESCRIPTION
## Description of the change

Make sure we are checking if there has been an error *before* we access the response struct (which will be nil in that case).

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1774

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: